### PR TITLE
Clean docs and add contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Guidelines
+
+- When modifying Python code, run `python -m py_compile $(find src -name '*.py')` to ensure syntax validity.
+- For UI changes, run `npm test` inside the `ui` directory if tests are available.
+- Keep documentation up to date and free of trailing whitespace.
+- Improvement notes and ideas should be placed in the `codex/` folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ For bugs or features, open an issue first.
 
 ## Code Style
 - Follow PEP8 for Python.
-- Use ESLint for JavaScript. 
+- Use ESLint for JavaScript.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ See [Pricing](#pricing) for details.
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
-This project is licensed under the AGPLv3 - see the [LICENSE](LICENSE) file for details. 
+This project is licensed under the AGPLv3 - see the [LICENSE](LICENSE) file for details.

--- a/codex/suggestions.md
+++ b/codex/suggestions.md
@@ -1,0 +1,7 @@
+# Improvement Suggestions
+
+- Add automated tests for the crawler, parser and API.
+- Harden the Docker images by using non-root users and minimal base images.
+- Consider adding an authentication layer to the REST API even for the community tier.
+- Provide CI scripts for linting Python with flake8 and running unit tests.
+- Expand the UI with status dashboards and crawl configuration.

--- a/docs/MRD-Research.md
+++ b/docs/MRD-Research.md
@@ -1,4 +1,3 @@
-
 Strategic Refinement and Competitive Analysis of the Self-Hosted Website Ingestion & Citation Service
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,4 +11,4 @@
 3. Run `docker-compose up -d`.
 4. Verify services are running.
 
-For Pro tier, configure subscription key. 
+For Pro tier, configure subscription key.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,24 @@
+# Usage Guide
+
+This document summarizes how to crawl a website and query the API.
+
+## Crawling
+
+Run the CLI crawler with:
+
+```bash
+python src/cli.py crawl --url https://example.com
+```
+
+## Querying
+
+Send a POST request to the `/query` endpoint:
+
+```bash
+curl -X POST http://localhost:5000/query \
+     -H 'Content-Type: application/json' \
+     -d '{"query": "Your question"}'
+```
+
+The API returns a JSON response containing the generated answer.
+


### PR DESCRIPTION
## Summary
- fix trailing whitespace and shell artifacts in markdown files
- add missing usage guide
- create `codex` folder with improvement suggestions
- document repo guidelines in `AGENTS.md`

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_687d7d72bfb0832292843d9e5921290d